### PR TITLE
Handle Pull Request Issues

### DIFF
--- a/tigris2github.py
+++ b/tigris2github.py
@@ -105,6 +105,9 @@ def get_relationship_text(tigris_issue, gh_issue, gh_issue_offset, field_name, r
     sorted_fields = sorted(tigris_issue.xpath(
         field_name), key=lambda x: x.xpath('when')[0].text)
     for field in sorted_fields:
+        if not field.xpath('issue_id')[0].text:
+            # Some relationships are empty, so skip over them.
+            continue
         suffix += '\r\n' + field.xpath('who')[0].text
         suffix += ' said this issue ' + relationship + ' #'
         suffix += str(int(field.xpath('issue_id')[0].text) + gh_issue_offset)

--- a/tigris2github.py
+++ b/tigris2github.py
@@ -206,10 +206,12 @@ def import_to_github(tigris_issue, repo, gh_issue_offset, user, passwd, attachme
         # https://developer.github.com/v3/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits
         time.sleep(1)
         gh_issue = repo.create_issue(title)
-        if gh_issue.number != issue_id:
-            print(issue_id, gh_issue.number)
-            # Someone's created an issue whilst we working, overwrite theirs.
-            gh_issue = repo.get_issue(issue_id)
+    time.sleep(1)
+    print('Importing Tigris issue {} as new issue {}: "{}"'.format(tigris_issue_id, issue_id, title))
+    if gh_issue.number != issue_id:
+        print(issue_id, gh_issue.number)
+        # Someone's created an issue whilst we working, overwrite theirs.
+        gh_issue = repo.get_issue(issue_id)
 
     state = 'open'
     if tigris_issue.xpath('issue_status')[0].text in (


### PR DESCRIPTION
This PR corrects the importing of issues from Tigris to GitHub when there are already Pull Requests associated with the target GitHub project. This fix only works when the PRs are in a cintguous block starting at 1. The result is that issues on GitHub have a different numerical value to on Tigris.

Examples of correct behvaiour include https://github.com/ajf58-org-sandbox/tigris-sandbox/issues/10, which also correctly references another issue at https://github.com/ajf58-org-sandbox/tigris-sandbox/issues/2477.

Resolves #2